### PR TITLE
Use assertEqual (singular) because assertEquals (plural) is deprecated

### DIFF
--- a/python/keyczar/test/util_test.py
+++ b/python/keyczar/test/util_test.py
@@ -124,9 +124,9 @@ class ParseX509Test(unittest.TestCase):
             '50905775'
             )
     }
-    self.assertEquals(len(expected),len(params))
+    self.assertEqual(len(expected),len(params))
     for key in expected:
-      self.assertEquals(expected[key],params[key])
+      self.assertEqual(expected[key],params[key])
 
 
 class Base64WSStreamingWriteTest(unittest.TestCase):


### PR DESCRIPTION
assertEqual() is used previously in this file so I do not expect to have any changes in the test results, aside from avoiding the DeprecationWarning this is targeting.